### PR TITLE
Fix deprecation error in quaternion.py

### DIFF
--- a/data_loaders/humanml/common/quaternion.py
+++ b/data_loaders/humanml/common/quaternion.py
@@ -8,9 +8,8 @@
 import torch
 import numpy as np
 
-_EPS4 = np.finfo(float).eps * 4.0
-
-_FLOAT_EPS = np.finfo(np.float).eps
+_FLOAT_EPS = np.finfo(np.float64).eps
+_EPS4 = _FLOAT_EPS * 4.0
 
 # PyTorch-backed implementations
 def qinv(q):


### PR DESCRIPTION
Previsouly, this caused:

```
AttributeError: module 'numpy' has no attribute 'float'.
`np.float` was a deprecated alias for the builtin `float`. To avoid this error in existing code, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations. Did you mean: 'cfloat'?
```