### PR TITLE
Fix bug in get_opt.py (Bool value read)

### DIFF
--- a/data_loaders/humanml/utils/get_opt.py
+++ b/data_loaders/humanml/utils/get_opt.py
@@ -40,7 +40,8 @@ def get_opt(opt_path, device):
                 # print(line.strip())
                 key, value = line.strip().split(': ')
                 if value in ('True', 'False'):
-                    opt_dict[key] = bool(value)
+                    # opt_dict[key] = bool(value)
+                    opt_dict[key] = (value == 'True')
                 elif is_float(value):
                     opt_dict[key] = float(value)
                 elif is_number(value):


### PR DESCRIPTION
The code for parsing the opt.txt file contains a critical bug: when the value is a boolean, the code consistently interprets it as 'True' since bool(string) == 'True' if and only if string is an empty string.